### PR TITLE
Adding a fix for crashes that occur when a space follows the template keyword

### DIFF
--- a/lib/puppet-lint/plugins/template_file_extension.rb
+++ b/lib/puppet-lint/plugins/template_file_extension.rb
@@ -19,6 +19,7 @@ PuppetLint.new_check(:template_file_extension) do
             extension = template_extensions[template_function.to_sym]
 
             current_token = value_token.next_token
+            current_token = current_token.next_token while current_token.type == :WHITESPACE
 
             # iterate over all the code tokens until we hit the closing ')'
             until current_token.type == :RPAREN || current_token.type == :LBRACE

--- a/puppet-lint-template_file_extension-check.gemspec
+++ b/puppet-lint-template_file_extension-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-template_file_extension-check'
-  spec.version     = '0.1.1'
+  spec.version     = '0.1.2'
   spec.homepage    = 'https://github.com/deanwilson/puppet-lint-template_file_extension-check'
   spec.license     = 'MIT'
   spec.author      = 'Dean Wilson'

--- a/spec/puppet-lint/plugins/puppet-lint-template_file_extension_spec.rb
+++ b/spec/puppet-lint/plugins/puppet-lint-template_file_extension_spec.rb
@@ -54,6 +54,22 @@ describe 'template_file_extension' do
     end
   end
 
+  context 'space between template and opening paren' do
+      let(:code) do
+        <<-EOS
+          class space_between_template_and_opening_paren {
+            file { '/tmp/templated':
+              content => template ('mymodule/a_file.erb'),
+            }
+          }
+        EOS
+      end
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+  end
+
   ##########################
   # Invalid examples
   ##########################
@@ -101,5 +117,26 @@ describe 'template_file_extension' do
       expect(problems).to contain_warning(epp_msg).on_line(3).in_column(24)
     end
   end
+
+  context 'space between template and opening paren and no extension' do
+      let(:code) do
+        <<-EOS
+          class space_between_template_and_opening_paren {
+            file { '/tmp/templated':
+              content => template ('mymodule/a_file'),
+            }
+          }
+        EOS
+      end
+
+      it 'should detect a single problem' do
+        expect(problems).to have(1).problem
+      end
+
+      it 'should create a warning' do
+        expect(problems).to contain_warning(template_msg).on_line(3).in_column(26)
+      end
+  end
+
 
 end


### PR DESCRIPTION
Currently, the code:

```puppet
file { '/myfile': content => template ('mymodule/mytemplate.erb'); }
```

...will cause `puppet-lint` to crash on line 27  (now 28), because of the whitespace token after `template`.  It's poor form, but it is accepted by the puppet parser, so whitespace should be ignored.