### PR TITLE
Fix issue#48 failing to detect a missing `.erb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [0.1.3] - 2020-12-08  Dean Wilson <dean.wilson@gmail.com>
+### Changed
+- added a test and fix for issue #48 - "Plugin does not always detect missing `.erb`" raised by @bastelfreak
 
 ## [0.1.1] - 2017-11-14  Dean Wilson <dean.wilson@gmail.com>
 

--- a/lib/puppet-lint/plugins/template_file_extension.rb
+++ b/lib/puppet-lint/plugins/template_file_extension.rb
@@ -5,6 +5,9 @@ PuppetLint.new_check(:template_file_extension) do
       template: '.erb',
     }
 
+    # the types a filename may be in a `template()` call
+    name_types = [:DQPOST, :SSTRING]
+
     resource_indexes.each do |resource|
       next unless resource[:type].value == 'file'
 
@@ -24,8 +27,7 @@ PuppetLint.new_check(:template_file_extension) do
           until current_token.type == :RPAREN || current_token.type == :LBRACE
             current_token = current_token.next_code_token
 
-            if current_token.type == :SSTRING && !current_token.value.end_with?(extension)
-
+            if (name_types.include? current_token.type) && !current_token.value.end_with?(extension)
               warning = "all #{template_function} file names should end with #{extension}"
 
               notify :warning, {

--- a/puppet-lint-template_file_extension-check.gemspec
+++ b/puppet-lint-template_file_extension-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-template_file_extension-check'
-  spec.version     = '0.1.2'
+  spec.version     = '0.1.3'
   spec.homepage    = 'https://github.com/deanwilson/puppet-lint-template_file_extension-check'
   spec.license     = 'MIT'
   spec.author      = 'Dean Wilson'

--- a/spec/puppet-lint/plugins/template_file_extension_spec.rb
+++ b/spec/puppet-lint/plugins/template_file_extension_spec.rb
@@ -168,4 +168,32 @@ describe 'template_file_extension' do
       expect(problems).to contain_warning(template_msg).on_line(3).in_column(24)
     end
   end
+
+  ##
+  # Reported bugs
+  ##
+
+  ## https://github.com/deanwilson/puppet-lint-template_file_extension-check/issues/48
+  context 'when the paramater type is DQPOST not SSTRING and no extension is provided (issue #48)' do
+    let(:template_msg) { 'all template file names should end with .erb' }
+
+    let(:code) do
+      <<-TEST_CLASS
+        class space_between_template_and_opening_paren {
+          file { "/etc/${package_name}.conf":
+            ensure  => file,
+            content => template("allknowingdns/${package_name}.conf"),
+          }
+        }
+      TEST_CLASS
+    end
+
+    it 'detects a single problem' do
+      expect(problems).to have(1).problem
+    end
+
+    it 'creates a warning' do
+      expect(problems).to contain_warning(template_msg).on_line(4).in_column(24)
+    end
+  end
 end


### PR DESCRIPTION
Apparently filenames are not always of type SSTRING and can be :DQPOST

"""
The part of the string from the last token until the end of the string
(e.g. If tokenising "foo ${bar} baz ${gronk} qux", the :DQPOST token
would have the value “ qux”)
"""