### PR TITLE
Modernise Ruby and Puppet versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,11 +6,11 @@ jobs:
   build:
     name: "Run Rspec Tests"
     env:
-      PUPPET_GEM_VERSION: "~> 8.6.0"
+      PUPPET_GEM_VERSION: "~> 8.10.0"
     strategy:
       fail-fast: false
       matrix:
-        ruby: [3.2]
+        ruby: [3.4]
     runs-on: ubuntu-22.04
 
     steps:

--- a/puppet-lint-template_file_extension-check.gemspec
+++ b/puppet-lint-template_file_extension-check.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     end with the string '.erb' or '.epp' respectively
   END_OF_DESCRIPTION
 
-  spec.required_ruby_version = '>= 3.2.0'
+  spec.required_ruby_version = '>= 3.4.0'
 
   spec.add_dependency             'puppet-lint', '>= 1.1', '< 6.0'
 


### PR DESCRIPTION
Update Ruby from 3.2 (EOL March 2026) to 3.4 and Puppet gem from 8.6 to 8.10.